### PR TITLE
Set ActiveStatus by default after version checking

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,6 +43,8 @@ class Operator(CharmBase):
         except NoCompatibleVersions as err:
             self.model.unit.status = BlockedStatus(str(err))
             return
+        else:
+            self.model.unit.status = ActiveStatus()
 
         for event in [
             self.on.install,


### PR DESCRIPTION
Prevents a charm from getting stuck in WaitingStatus