### PR TITLE
Fix Client Secret Desynchronization

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,9 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     upstream-source: gcr.io/arrikto/kubeflow/oidc-authservice:fef11c3
+peers:
+  client-secret:
+    interface: client-secret
 provides:
   oidc-client:
     interface: oidc-client

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,5 +1,5 @@
 import pytest
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 import yaml
 
@@ -13,7 +13,7 @@ def harness():
 
 def test_not_leader(harness):
     harness.begin()
-    assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
+    assert harness.charm.model.unit.status == ActiveStatus()
 
 
 def test_missing_image(harness):


### PR DESCRIPTION
- Handle Client Secret through peer relation instead of StoredState

- Pass to an Active State instead of Waiting if not a leader and stop observing leader_elected event.

Should fix these 2 bugs:
https://github.com/canonical/bundle-kubeflow/issues/354
https://github.com/canonical/bundle-kubeflow/issues/351