### PR TITLE
Build Charm through tox with local Schemas

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,11 +60,12 @@ jobs:
     - name: Install dependencies
       run: |
         set -eux
-        sudo pip3 install charmcraft
+        sudo snap install charmcraft
         sudo snap install juju --classic
         sudo snap install juju-helpers --classic
         sudo snap install juju-wait --classic
         sudo snap install yq
+        sudo apt-get install python3-pip tox
 
     - name: Bootstrap Juju
       run: |
@@ -82,7 +83,7 @@ jobs:
     - name: Deploy charm
       run: |
         set -eux
-        charmcraft build -v
+        tox -e build
         juju deploy ./*.charm \
           --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
         juju relate dex-auth:oidc-client oidc-gatekeeper:oidc-client

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
         CS_URL="cs:~dex-charmers/oidc-gatekeeper"
 
         IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
-        charmcraft build
+        tox -e build
         docker pull $IMAGE
         charm push ./*.charm $CS_URL --resource oci-image=$IMAGE
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ops==1.1.0
 oci-image==1.0.0
-serialized-data-interface==0.2.0
+serialized-data-interface==0.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ setenv =
 deps =
     -rtest-requirements.txt
     -rrequirements.txt
+allowlist_externals =
+    charmcraft
 
 [testenv:unit]
 commands =
@@ -20,3 +22,7 @@ commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests
 
+[testenv:build]
+commands =
+    charmcraft build
+    python3 -m serialized_data_interface.local_sdi


### PR DESCRIPTION
Adds build step in tox.ini for building the charm and injecting local SDI schemas into the build zip.

Depends on [this](https://github.com/canonical/serialized-data-interface/pull/12) being merged and published.