### PR TITLE
exit function if not a leader

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -37,11 +37,9 @@ class Operator(CharmBase):
             self.framework.observe(event, self.main)
 
     def main(self, event):
-        if not self.unit.is_leader():
-            self.model.unit.status = WaitingStatus("Waiting for Leadership")
-            exit()
-
         try:
+            self._check_leader()
+
             interfaces = self._get_interfaces()
 
             secret_key = self._check_secret()
@@ -90,6 +88,11 @@ class Operator(CharmBase):
         )
 
         self.model.unit.status = ActiveStatus()
+
+    def _check_leader(self):
+        if not self.unit.is_leader():
+            self.log.info("Not a leader, skipping set_pod_spec")
+            raise CheckFailed("Waiting for leadership", WaitingStatus)
 
     def _get_interfaces(self):
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,8 @@ class Operator(CharmBase):
         self.image = OCIImageResource(self, "oci-image")
 
         for event in [
-            self.on.install,
+            self.on.start,
+            self.on.leader_elected,
             self.on.upgrade_charm,
             self.on.config_changed,
             self.on["ingress"].relation_changed,
@@ -36,6 +37,10 @@ class Operator(CharmBase):
             self.framework.observe(event, self.main)
 
     def main(self, event):
+        if not self.unit.is_leader():
+            self.model.unit.status = WaitingStatus("Waiting for Leadership")
+            exit()
+
         try:
             interfaces = self._get_interfaces()
 
@@ -164,9 +169,9 @@ class CheckFailed(Exception):
     def __init__(self, msg, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,8 @@ OIDC_CONFIG = {
     "client-name": "Ambassador Auth OIDC",
     "client-secret": "oidc-client-secret",
 }
+ISTIO_PILOT = "istio-pilot"
+DEX_AUTH = "dex-auth"
 
 
 @pytest.mark.abort_on_fail
@@ -36,16 +38,28 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_relations(ops_test: OpsTest):
-    istio_pilot = "istio-pilot"
-    dex_auth = "dex-auth"
-    await ops_test.model.deploy(istio_pilot, channel="1.5/stable")
-    await ops_test.model.deploy(dex_auth)
-    await ops_test.model.add_relation(istio_pilot, dex_auth)
-    await ops_test.model.add_relation(f"{istio_pilot}:ingress", f"{APP_NAME}:ingress")
-    await ops_test.model.add_relation(f"{istio_pilot}:ingress-auth", f"{APP_NAME}:ingress-auth")
+    await ops_test.model.deploy(ISTIO_PILOT, channel="1.5/stable")
+    await ops_test.model.deploy(DEX_AUTH)
+    await ops_test.model.add_relation(ISTIO_PILOT, DEX_AUTH)
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{APP_NAME}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress-auth", f"{APP_NAME}:ingress-auth")
 
     await ops_test.model.wait_for_idle(
-        [APP_NAME, istio_pilot, dex_auth],
+        [APP_NAME, ISTIO_PILOT, DEX_AUTH],
+        status="active",
+        raise_on_blocked=True,
+        raise_on_error=True,
+        timeout=600,
+    )
+
+
+async def test_update_public_url(ops_test: OpsTest):
+    public_url = "test-url"
+    await ops_test.model.applications[DEX_AUTH].set_config({"public-url": public_url})
+    await ops_test.model.applications[APP_NAME].set_config({"public-url": public_url})
+
+    await ops_test.model.wait_for_idle(
+        [APP_NAME, DEX_AUTH],
         status="active",
         raise_on_blocked=True,
         raise_on_error=True,

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -3,7 +3,7 @@
 
 import pytest
 import yaml
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import Operator
@@ -12,6 +12,11 @@ from charm import Operator
 @pytest.fixture
 def harness():
     return Harness(Operator)
+
+
+def test_not_leader(harness):
+    harness.begin_with_initial_hooks()
+    assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
 
 def test_missing_image(harness):


### PR DESCRIPTION
Do not proceed with main function unless it is a leader unit
It was causing transient errors when switching units (e.g. upgrade charm, public url config update)

Tested this against the integration test in [this pr](https://github.com/canonical/dex-auth-operator/pull/40). I was able to wait for idle with `raise_on_error=True` after updating public url