### PR TITLE
use latest black

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ pytest
 flake8
 flake8-copyright<0.3
 pyproject-flake8
-black==20.8b1
+black
 isort


### PR DESCRIPTION
old black versions would fail as certain file no longer exist in click. Update test dependency to use black's latest version