### PR TITLE
Upgrade for 1.6 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 .tox/
 __pycache__
+.idea

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,5 @@ options:
     description: Publicly-accessible endpoint for cluster
   oidc-scopes:
     type: string
-    default: 'profile email groups'
+    default: 'profile,email,groups'
     description: OpenID Connect scopes
-  

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/arrikto/kubeflow/oidc-authservice:fef11c3
+    upstream-source: gcr.io/arrikto/kubeflow/oidc-authservice:e236439
 peers:
   client-secret:
     interface: client-secret

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,6 +79,7 @@ class Operator(CharmBase):
                             "USERID_HEADER": "kubeflow-userid",
                             "USERID_PREFIX": "",
                             "SESSION_STORE_PATH": "bolt.db",
+                            "OIDC_STATE_STORE_PATH": "bolt.db",
                             "SKIP_AUTH_URLS": "/dex/",
                             "AUTHSERVICE_URL_PREFIX": "/authservice/",
                         },

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,7 +39,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_relations(ops_test: OpsTest):
     await ops_test.model.deploy(ISTIO_PILOT, channel="1.5/stable")
-    await ops_test.model.deploy(DEX_AUTH, channel="latest/edge")
+    await ops_test.model.deploy(DEX_AUTH, channel="latest/edge", trust=True)
     await ops_test.model.add_relation(ISTIO_PILOT, DEX_AUTH)
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{APP_NAME}:ingress")
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress-auth", f"{APP_NAME}:ingress-auth")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,7 +39,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_relations(ops_test: OpsTest):
     await ops_test.model.deploy(ISTIO_PILOT, channel="1.5/stable")
-    await ops_test.model.deploy(DEX_AUTH)
+    await ops_test.model.deploy(DEX_AUTH, channel="latest/edge")
     await ops_test.model.add_relation(ISTIO_PILOT, DEX_AUTH)
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{APP_NAME}:ingress")
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress-auth", f"{APP_NAME}:ingress-auth")


### PR DESCRIPTION
This PR is still WIP - the container is running and charm gets active, but the dashboard can't be accessed.
TODO: Review upstream changes from 4 Jun 2020 (release date of the previous image) to 5 Oct 2021.