### PR TITLE
fix: unpin flake8

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 pytest
-flake8==4.0.1
+flake8
 flake8-copyright<0.3
 pyproject-flake8
 black


### PR DESCRIPTION
Unpins flake8 to fix a version incompatibility between flake8 and pyflake8.  Previously, we pinned flake8 because some of the flake8 packages we used did not support the latest version.  Now, those are fixed, but pyflake8 does not support the older version of flake8.  Unpinning fixes all of this.