### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,14 +21,90 @@ peers:
 provides:
   oidc-client:
     interface: oidc-client
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/oidc-schemas/oidc-client.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            redirectURIs:
+              type: array
+              items:
+                type: string
+            secret:
+              type: string
+          required:
+          - id
+          - name
+          - redirectURIs
+          - secret
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/oidc-schemas/oidc-client.yaml
 requires:
   ingress:
     interface: ingress
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress.yaml
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress.yaml
   ingress-auth:
     interface: ingress-auth
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress-auth.yaml
+    schema:
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            allowed-request-headers:
+              type: array
+              items:
+                type: string
+            allowed-response-headers:
+              type: array
+              items:
+                type: string
+          required:
+          - service
+          - port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress-auth.yaml


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).