### PR TITLE
fix: define OIDC_STATE_STORE_PATH env variable

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -76,7 +76,7 @@ class Operator(CharmBase):
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "SESSION_STORE_PATH": "bolt.db",
-                        "OIDC_STATE_STORE_PATH": "oidc_state.db",   # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64  # noqa E501
+                        "OIDC_STATE_STORE_PATH": "oidc_state.db",  # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64  # noqa E501
                         "SKIP_AUTH_URLS": "/dex/" if len(skip_urls) == 0 else "/dex/," + skip_urls,
                         "AUTHSERVICE_URL_PREFIX": "/authservice/",
                     },

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,7 +76,7 @@ class Operator(CharmBase):
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "SESSION_STORE_PATH": "bolt.db",
-                        "OIDC_STATE_STORE_PATH": "oidc_state.db",   # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64 
+                        "OIDC_STATE_STORE_PATH": "oidc_state.db",   # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64  # noqa E501
                         "SKIP_AUTH_URLS": "/dex/" if len(skip_urls) == 0 else "/dex/," + skip_urls,
                         "AUTHSERVICE_URL_PREFIX": "/authservice/",
                     },

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,6 +76,7 @@ class Operator(CharmBase):
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "SESSION_STORE_PATH": "bolt.db",
+                        "OIDC_STATE_STORE_PATH": "oidc_state.db",
                         "SKIP_AUTH_URLS": "/dex/" if len(skip_urls) == 0 else "/dex/," + skip_urls,
                         "AUTHSERVICE_URL_PREFIX": "/authservice/",
                     },

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,7 +76,7 @@ class Operator(CharmBase):
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "SESSION_STORE_PATH": "bolt.db",
-                        "OIDC_STATE_STORE_PATH": "oidc_state.db",
+                        "OIDC_STATE_STORE_PATH": "oidc_state.db",   # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64 
                         "SKIP_AUTH_URLS": "/dex/" if len(skip_urls) == 0 else "/dex/," + skip_urls,
                         "AUTHSERVICE_URL_PREFIX": "/authservice/",
                     },

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -157,3 +157,33 @@ def test_ca_bundle_config(harness):
     pod_spec, _ = harness.get_pod_spec()
 
     assert pod_spec["containers"][0]["envConfig"]["CA_BUNDLE"] == "/etc/certs/oidc/root-ca.pem"
+
+
+def test_session_store_path(harness):
+    harness.set_leader(True)
+    harness.add_oci_resource(
+        "oci-image",
+        {
+            "registrypath": "ci-test",
+            "username": "",
+            "password": "",
+        },
+    )
+    harness.begin_with_initial_hooks()
+    pod_spec, _ = harness.get_pod_spec()
+    assert pod_spec["containers"][0]["envConfig"]["SESSION_STORE_PATH"] == "bolt.db"
+
+
+def test_oidc_state_store_path(harness):
+    harness.set_leader(True)
+    harness.add_oci_resource(
+        "oci-image",
+        {
+            "registrypath": "ci-test",
+            "username": "",
+            "password": "",
+        },
+    )
+    harness.begin_with_initial_hooks()
+    pod_spec, _ = harness.get_pod_spec()
+    assert pod_spec["containers"][0]["envConfig"]["OIDC_STATE_STORE_PATH"] == "oidc_state.db"


### PR DESCRIPTION
fixes #64 
In the upgrade of oidc from `fef11c3` -> `e236439`, an env variable `OIDC_STATE_STORE_PATH` was introduced that defaults to "/var/lib/authservice/oidc_state.db", reference [here](https://github.com/arrikto/oidc-authservice/tree/master#options). Currently, the /var/lib/authservice/ path does not exist in the container causing the error `fatal msg="Error creating oidc state store: open /var/lib/authservice/data.db: no such file or directory"`.
