### PR TITLE
Add a default `public-url` config value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,8 +20,10 @@ options:
     description: OpenID Connect client secret
   public-url:
     type: string
-    default: ''
-    description: Publicly-accessible endpoint for cluster
+    default: 'http://dex-auth.kubeflow.svc.cluster.local:5556'
+    description: | 
+      Publicly-accessible endpoint for cluster, or the kubernetes internally-accessible 
+      url for dex-auth.
   oidc-scopes:
     type: string
     default: 'profile email groups'

--- a/src/charm.py
+++ b/src/charm.py
@@ -40,10 +40,8 @@ class OIDCGatekeeperOperator(CharmBase):
         if not self.public_url.startswith(("http://", "https://")):
             self.public_url = f"http://{self.public_url}"
 
-        # If public_url is a kubernetes-internal URL, it points directly to dex.  Otherwise, we
-        # need to route to /dex
-        kubernetes_internal_url_pattern = r".+\.svc\.cluster\.local\:\d+"
-        if not re.match(kubernetes_internal_url_pattern, self.public_url):
+        self.public_url = self.public_url.rstrip("/")
+        if not self.public_url.endswith("/dex"):
             self.public_url += "/dex"
 
         for event in [


### PR DESCRIPTION
This adds a default `public-url` config value as described in canonical/bundle-kubeflow#608.  After implementing canonical/bundle-kubeflow#608 as a whole, we remove the need for users to modify `public-url`.

Also implemented here are other config values that are required to make the new public-url default work properly.

While we could deprecate and remove the `public-url` config, it is recommended we leave it as is with this default.  This is because in the medium term we plan on replacing dex+oidc with a different auth setup.  