### PR TITLE
fix: Block charm when public-url is not configured

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -42,6 +42,8 @@ class Operator(CharmBase):
 
             image_details = self._check_image_details()
 
+            self._check_public_url()
+
         except CheckFailed as error:
             self.model.unit.status = error.status
             return

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,7 @@ OIDC_CONFIG = {
     "client-name": "Ambassador Auth OIDC",
     "client-secret": "oidc-client-secret",
 }
+OIDC_URL = "https://10.64.140.43.nip.io"
 ISTIO_PILOT = "istio-pilot"
 DEX_AUTH = "dex-auth"
 
@@ -30,6 +31,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy(
         charm_under_test, resources=resources, trust=True, config=OIDC_CONFIG
     )
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=60 * 10
+    )
+    # Set config for public-url in order to unblock charm
+    await ops_test.model.applications[APP_NAME].set_config({"public-url": OIDC_URL})
+
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,9 +31,8 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy(
         charm_under_test, resources=resources, trust=True, config=OIDC_CONFIG
     )
-
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=60 * 10
+        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
     )
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,7 +39,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.applications[APP_NAME].set_config({"public-url": OIDC_URL})
 
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=60 * 10
+        apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=60 * 10
     )
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -12,8 +12,8 @@ APP_NAME = METADATA["name"]
 OIDC_CONFIG = {
     "client-name": "Ambassador Auth OIDC",
     "client-secret": "oidc-client-secret",
+    "public-url": "https://10.64.140.43.nip.io"
 }
-OIDC_URL = "https://10.64.140.43.nip.io"
 ISTIO_PILOT = "istio-pilot"
 DEX_AUTH = "dex-auth"
 
@@ -31,12 +31,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy(
         charm_under_test, resources=resources, trust=True, config=OIDC_CONFIG
     )
-
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=60 * 10
-    )
-    # Set config for public-url in order to unblock charm
-    await ops_test.model.applications[APP_NAME].set_config({"public-url": OIDC_URL})
 
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=60 * 10

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -12,7 +12,7 @@ APP_NAME = METADATA["name"]
 OIDC_CONFIG = {
     "client-name": "Ambassador Auth OIDC",
     "client-secret": "oidc-client-secret",
-    "public-url": "https://10.64.140.43.nip.io"
+    "public-url": "https://10.64.140.43.nip.io",
 }
 ISTIO_PILOT = "istio-pilot"
 DEX_AUTH = "dex-auth"

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -11,7 +11,9 @@ from charm import Operator
 
 @pytest.fixture
 def harness():
-    return Harness(Operator)
+    harness = Harness(Operator)
+    harness.update_config({"public-url": "10.64.140.43.nip.io"})
+    return harness
 
 
 def test_not_leader(harness):
@@ -35,6 +37,7 @@ def test_missing_public_url(harness):
             "password": "",
         },
     )
+    harness.update_config({"public-url": ""})
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == BlockedStatus("public-url config required")
 
@@ -51,7 +54,6 @@ def test_no_relation(harness):
     )
     harness.begin_with_initial_hooks()
 
-    harness.update_config({"public-url": "10.64.140.43.nip.io"})
     assert harness.charm.model.unit.status == ActiveStatus()
 
 
@@ -65,7 +67,6 @@ def test_with_relation(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "10.64.140.43.nip.io"})
     rel_id = harness.add_relation("ingress", "app")
 
     harness.add_relation_unit(rel_id, "app/0")
@@ -91,7 +92,6 @@ def test_public_url_prepend_http(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -132,9 +132,7 @@ def test_skip_auth_url_config_has_value(harness):
             "password": "",
         },
     )
-    harness.update_config(
-        {"public-url": "https://10.64.140.43.nip.io", "skip-auth-urls": "/test/,/path1/"}
-    )
+    harness.update_config({"skip-auth-urls": "/test/,/path1/"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -152,7 +150,6 @@ def test_skip_auth_url_config_is_empty(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -170,7 +167,7 @@ def test_ca_bundle_config(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "https://10.64.140.43.nip.io", "ca-bundle": "aaa"})
+    harness.update_config({"ca-bundle": "aaa"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -188,7 +185,6 @@ def test_session_store_path(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
     pod_spec, _ = harness.get_pod_spec()
     assert pod_spec["containers"][0]["envConfig"]["SESSION_STORE_PATH"] == "bolt.db"
@@ -204,7 +200,6 @@ def test_oidc_state_store_path(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
     pod_spec, _ = harness.get_pod_spec()
     assert pod_spec["containers"][0]["envConfig"]["OIDC_STATE_STORE_PATH"] == "oidc_state.db"

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -24,6 +24,19 @@ def test_missing_image(harness):
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == BlockedStatus("Missing resource: oci-image")
 
+def test_missing_public_url(harness):
+    harness.set_leader(True)
+    harness.add_oci_resource(
+        "oci-image",
+        {
+            "registrypath": "ci-test",
+            "username": "",
+            "password": "",
+        },
+    )
+    harness.begin_with_initial_hooks()
+    assert harness.charm.model.unit.status == BlockedStatus("public-url config required")
+
 
 def test_no_relation(harness):
     harness.set_leader(True)
@@ -37,6 +50,7 @@ def test_no_relation(harness):
     )
     harness.begin_with_initial_hooks()
 
+    harness.update_config({"public-url": "10.64.140.43.nip.io"})
     assert harness.charm.model.unit.status == ActiveStatus()
 
 
@@ -50,6 +64,7 @@ def test_with_relation(harness):
             "password": "",
         },
     )
+    harness.update_config({"public-url": "10.64.140.43.nip.io"})
     rel_id = harness.add_relation("ingress", "app")
 
     harness.add_relation_unit(rel_id, "app/0")
@@ -116,7 +131,7 @@ def test_skip_auth_url_config_has_value(harness):
             "password": "",
         },
     )
-    harness.update_config({"skip-auth-urls": "/test/,/path1/"})
+    harness.update_config({"public-url": "https://10.64.140.43.nip.io", "skip-auth-urls": "/test/,/path1/"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -134,6 +149,7 @@ def test_skip_auth_url_config_is_empty(harness):
             "password": "",
         },
     )
+    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -151,7 +167,7 @@ def test_ca_bundle_config(harness):
             "password": "",
         },
     )
-    harness.update_config({"ca-bundle": "aaa"})
+    harness.update_config({"public-url": "https://10.64.140.43.nip.io", "ca-bundle": "aaa"})
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()
@@ -169,6 +185,7 @@ def test_session_store_path(harness):
             "password": "",
         },
     )
+    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
     pod_spec, _ = harness.get_pod_spec()
     assert pod_spec["containers"][0]["envConfig"]["SESSION_STORE_PATH"] == "bolt.db"
@@ -184,6 +201,7 @@ def test_oidc_state_store_path(harness):
             "password": "",
         },
     )
+    harness.update_config({"public-url": "https://10.64.140.43.nip.io"})
     harness.begin_with_initial_hooks()
     pod_spec, _ = harness.get_pod_spec()
     assert pod_spec["containers"][0]["envConfig"]["OIDC_STATE_STORE_PATH"] == "oidc_state.db"

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -24,6 +24,7 @@ def test_missing_image(harness):
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == BlockedStatus("Missing resource: oci-image")
 
+
 def test_missing_public_url(harness):
     harness.set_leader(True)
     harness.add_oci_resource(
@@ -131,7 +132,9 @@ def test_skip_auth_url_config_has_value(harness):
             "password": "",
         },
     )
-    harness.update_config({"public-url": "https://10.64.140.43.nip.io", "skip-auth-urls": "/test/,/path1/"})
+    harness.update_config(
+        {"public-url": "https://10.64.140.43.nip.io", "skip-auth-urls": "/test/,/path1/"}
+    )
     harness.begin_with_initial_hooks()
 
     pod_spec, _ = harness.get_pod_spec()


### PR DESCRIPTION
We realised in https://github.com/canonical/oidc-gatekeeper-operator/issues/107 that charm doesn't block public-url is not configured. Thus, this fixes the issue setting the status to Blocked when configuration `public-url` is not there.
Closes https://github.com/canonical/oidc-gatekeeper-operator/issues/107