### PR TITLE
feat: add config for USERID_CLAIM env var

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,3 +38,7 @@ options:
       If not empty, this is a comma-separated list of paths, e.g. "/path1/,/path2/".
       That list defines which paths do not need to be authenticated on OIDC.
       The DEX path is always added to this list.
+  userid-claim:
+    type: string
+    default: 'email'
+    description: OpenID Connect claim whose value will be used as the userid.

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,6 +82,7 @@ class OIDCGatekeeperOperator(CharmBase):
             "OIDC_PROVIDER": f"{self.public_url}/dex",
             "OIDC_SCOPES": self.model.config["oidc-scopes"],
             "SERVER_PORT": self._http_port,
+            "USERID_CLAIM": self.model.config["userid-claim"],
             "USERID_HEADER": "kubeflow-userid",
             "USERID_PREFIX": "",
             "SESSION_STORE_PATH": "bolt.db",


### PR DESCRIPTION
fixes #99 

## Summary
Adds a config to the charm that enables setting the USERID_CLAIM env var. This env var tells oidc what claim to use in setting the value of the `kubeflow-userid` header.

## Manual testing
* deploy Charmed Kubeflow latest/edge
* Access the dashboard - [instructions](https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow#heading--configure-the-charmed-kubeflow-components)
* refresh oidc to the charm in this branch
* make a request to jupyter-ui by accessing Notebooks from the dashboard
**Note** we can use the jupyter-ui logs to check on this value since it's printed in the logs every time jupyter-ui gets a request, see [upstream code](https://github.com/kubeflow/kubeflow/blob/master/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py#L19-L20).
* set the backend-mode of jupyter-ui to `development` in order to be able to see debug logs
  ```
  juju config jupyter-ui backend-mode=development
  ```
* check the value recorded in `kubeflow-userid`, by default it's the `username` set in dex, to see the `jupyter-ui` logs run:
  ```
  kubectl logs jupyter-ui-0 -nkubeflow -c jupyter-ui | grep kubeflow-userid
  ```
  Output:
  ```
  2023-09-06T13:07:46.453Z [jupyter-ui] 2023-09-06 13:07:46,453 | kubeflow.kubeflow.crud_backend.authn | DEBUG | User: 'admin' | Headers: 'kubeflow-userid' ''
  ```
  the `User: 'admin'` part shows that the ID is currently set to the username
* change the new config to be something other than username, the list of claims can be found [here](https://openid.net/specs/openid-connect-core-1_0.html#Claims). In this test, we're setting it to `sub`:
  ```
  juju config oidc-gatekeeper userid-claim=sub
  ```
* try to acces Notebooks UI once more
* check the jupyter-ui logs:
  ```
  kubectl logs jupyter-ui-0 -nkubeflow -c jupyter-ui | grep kubeflow-userid
  ```
  Output:
  ```
  2023-09-07T09:17:48.620Z [jupyter-ui] 2023-09-07 09:17:48,619 | kubeflow.kubeflow.crud_backend.authn | DEBUG | User: 'CiRkZmY2YjQ0Ny1hNzk2LTQ4ZGQtODVhMC04YTA5YTBmMTM4NWESBWxvY2Fs' | Headers: 'kubeflow-userid' ''
  ```
  now `User` shows a different value that's the identifier for the End-User at the issuer (dex)