### PR TITLE
feat: set oidc-authservice image source to kubeflow-owned registry

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/arrikto/kubeflow/oidc-authservice:e236439
+    upstream-source: docker.io/kubeflowmanifestswg/oidc-authservice:e236439
 peers:
   client-secret:
     interface: client-secret


### PR DESCRIPTION
Changes the source of the oci-image from arrikto registry to kubeflow-owned registry.
This commit should also be cherry-picked to main.