### PR TITLE
use rock for oidc-authservice on `track/ckf-1.7`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/arrikto/kubeflow/oidc-authservice:e236439
+    upstream-source: charmedkubeflow/oidc-authservice:ckf-1.7_9517371
 peers:
   client-secret:
     interface: client-secret


### PR DESCRIPTION
updates the charm to use a rock for oidc-authservice, as built from https://github.com/canonical/oidc-authservice-rock/tree/track/ckf-1.7