### PR TITLE
explicitly set working-dir for workload in charm.py

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -117,6 +117,12 @@ class OIDCGatekeeperOperator(CharmBase):
                     "command": "/home/authservice/oidc-authservice",
                     "environment": self.service_environment,
                     "startup": "enabled",
+                    # working-dir is required to interchangeably support docker images and rocks.
+                    # Rocks always set their entrypoint working-dir to "/" because pebble is the
+                    # entrypoint, so we need to be explicit.  This was not needed for running
+                    # the upstream docker image because that image has a entrypoint working-dir
+                    # of "/home/authservice", which is used if working-dir is not set here.
+                    "working-dir": "/home/authservice",
                 }
             },
         }

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,11 +117,8 @@ class OIDCGatekeeperOperator(CharmBase):
                     "command": "/home/authservice/oidc-authservice",
                     "environment": self.service_environment,
                     "startup": "enabled",
-                    # working-dir is required to interchangeably support docker images and rocks.
-                    # Rocks always set their entrypoint working-dir to "/" because pebble is the
-                    # entrypoint, so we need to be explicit.  This was not needed for running
-                    # the upstream docker image because that image has a entrypoint working-dir
-                    # of "/home/authservice", which is used if working-dir is not set here.
+                    # See https://github.com/canonical/oidc-gatekeeper-operator/pull/128
+                    # for context on why we need working-dir set here.
                     "working-dir": "/home/authservice",
                 }
             },


### PR DESCRIPTION
This adds a working-dir argument for the oidc-authservice pebble plan.  This is required to allow a rock of the upstream image to be drop-in replacement.  

This also may fix #126, although I don't understand why this would be the cause of that issue.  