### PR TITLE
use rock for oidc-authservice on `main` for ckf-1.8

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflowmanifestswg/oidc-authservice:e236439
+    upstream-source: charmedkubeflow/oidc-authservice:ckf-1.8-58e8217
 peers:
   client-secret:
     interface: client-secret


### PR DESCRIPTION
Closes #131

Testing notes: Because this repo's test suite has given some false passes lately, I've also tested this manually using dex-auth's tests and it worked as expected.  Once this is merged and pushed to charmhub, we should re-trigger dex-auth's CI just to demonstrate publicly how it really works