### PR TITLE
cherry pick rock, `workingdir` fix to main

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflowmanifestswg/oidc-authservice:e236439
+    upstream-source: charmedkubeflow/oidc-authservice:ckf-1.8-58e8217
 peers:
   client-secret:
     interface: client-secret

--- a/src/charm.py
+++ b/src/charm.py
@@ -117,6 +117,9 @@ class OIDCGatekeeperOperator(CharmBase):
                     "command": "/home/authservice/oidc-authservice",
                     "environment": self.service_environment,
                     "startup": "enabled",
+                    # See https://github.com/canonical/oidc-gatekeeper-operator/pull/128
+                    # for context on why we need working-dir set here.
+                    "working-dir": "/home/authservice",
                 }
             },
         }


### PR DESCRIPTION
Cherry pick from main to track/ckf-1.8:
* explicitly set workingdir for workload in charm.py 
* [use rock for oidc-authservice on main for ckf-1.8