### PR TITLE
feat: add OIDC_AUTH_URL and AFTER_LOGIN_URL env variables (#136)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -77,9 +77,13 @@ class OIDCGatekeeperOperator(CharmBase):
         dex_skip_urls = "/dex/" if not skip_urls else "/dex/," + skip_urls
 
         ret_env_vars = {
+            "AFTER_LOGIN_URL": "/",
+            "AFTER_LOGOUT_URL": "/",
+            "AUTHSERVICE_URL_PREFIX": "/authservice/",
             "CLIENT_ID": self.model.config["client-id"],
             "CLIENT_SECRET": secret_key,
             "DISABLE_USERINFO": True,
+            "OIDC_AUTH_URL": "/dex/auth",
             "OIDC_PROVIDER": f"{self.public_url}/dex",
             "OIDC_SCOPES": self.model.config["oidc-scopes"],
             "SERVER_PORT": self._http_port,
@@ -90,8 +94,6 @@ class OIDCGatekeeperOperator(CharmBase):
             # Added to fix https://github.com/canonical/oidc-gatekeeper-operator/issues/64
             "OIDC_STATE_STORE_PATH": "oidc_state.db",
             "SKIP_AUTH_URLS": dex_skip_urls,
-            "AUTHSERVICE_URL_PREFIX": "/authservice/",
-            "AFTER_LOGOUT_URL": self.model.config["public-url"],
         }
 
         if self.model.config["ca-bundle"]:


### PR DESCRIPTION
* feat: add OIDC_AUTH_URL and AFTER_LOGIN_URL env variables

These variables are required by the OIDC Authservice to correctly redirect users along the authentication flow.
* OIDC_AUTH_URL: is used as the URL tht Authservice will hit for initiating the auth flow
* AFTER_LOGIN_URL: is used for redirecting after login
* AFTER_LOGOUT_URL: is used for redirecting after logout.

These variables are required because the default behaviour of OIDC Authservice is to redirect to URLs that can be undesired, by setting them up, we have a deterministic way of setting where users should be redirected.

Part of canonical/bundle-kubeflow#608
Fixes #138 