### PR TITLE
pin integration test dependencies, refactor constants in tests for main

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,13 +8,22 @@ from pytest_operator.plugin import OpsTest
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+PREVIOUS_RELEASE = "ckf-1.8/stable"
+PREVIOUS_RELEASE_TRUST = True
 OIDC_CONFIG = {
     "client-name": "Ambassador Auth OIDC",
     "client-secret": "oidc-client-secret",
 }
+
 ISTIO_PILOT = "istio-pilot"
+ISTIO_PILOT_CHANNEL = "latest/edge"
+ISTIO_PILOT_TRUST = True
+
 DEX_AUTH = "dex-auth"
+DEX_AUTH_CHANNEL = "latest/edge"
+DEX_AUTH_TRUST = True
 PUBLIC_URL = "test-url"
+
 image_path = METADATA["resources"]["oci-image"]["upstream-source"]
 RESOURCES = {"oci-image": image_path}
 
@@ -37,7 +46,10 @@ class TestOIDCOperator:
         Assert on the unit status.
         """
         await ops_test.model.deploy(
-            pytest.charm_under_test, resources=RESOURCES, trust=True, config=OIDC_CONFIG
+            pytest.charm_under_test,
+            resources=RESOURCES,
+            trust=True,
+            config=OIDC_CONFIG,
         )
 
         await ops_test.model.applications[APP_NAME].set_config({"public-url": PUBLIC_URL})
@@ -49,8 +61,12 @@ class TestOIDCOperator:
 
     @pytest.mark.abort_on_fail
     async def test_relations(self, ops_test: OpsTest):
-        await ops_test.model.deploy(ISTIO_PILOT, channel="1.16/stable", trust=True)
-        await ops_test.model.deploy(DEX_AUTH, channel="2.31/stable", trust=True)
+        await ops_test.model.deploy(
+            ISTIO_PILOT,
+            channel=ISTIO_PILOT_CHANNEL,
+            trust=ISTIO_PILOT_TRUST,
+        )
+        await ops_test.model.deploy(DEX_AUTH, channel=DEX_AUTH_CHANNEL, trust=DEX_AUTH_TRUST)
         await ops_test.model.add_relation(ISTIO_PILOT, DEX_AUTH)
         await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{APP_NAME}:ingress")
         await ops_test.model.add_relation(
@@ -80,7 +96,7 @@ class TestOIDCOperator:
     async def test_upgrade(self, ops_test: OpsTest):
         """Test that charm can be upgraded from podspec to sidecar.
 
-        For this test we use 1.7/stable channel as the source for podspec charm.
+        For this test we use APP_PREV_VERSION channel as the source for podspec charm.
 
         Note: juju has a bug due to which you have to first scale podspec charm to 0,
         then refresh, then scale up newly deployed app.
@@ -88,7 +104,10 @@ class TestOIDCOperator:
         """
         print(f"Deploy {APP_NAME} from stable channel")
         await ops_test.model.deploy(
-            APP_NAME, channel="ckf-1.7/stable", trust=True, config=OIDC_CONFIG
+            APP_NAME,
+            channel=PREVIOUS_RELEASE,
+            trust=PREVIOUS_RELEASE_TRUST,
+            config=OIDC_CONFIG,
         )
         await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{APP_NAME}:ingress")
         await ops_test.model.add_relation(


### PR DESCRIPTION
Pins dependencies in the integration tests to their corresponding channels for this development branch.

Ref: https://github.com/canonical/bundle-kubeflow/issues/866