### PR TITLE
Add teraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -42,6 +42,14 @@ jobs:
 
       - name: Run unit tests
         run: tox -e unit
+  
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
 
   integration:
     name: Integration Tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 .tox/
 __pycache__
 .idea
+.terraform*
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for oidc-gatekeeper
+
+This is a Terraform module facilitating the deployment of oidc-gatekeeper charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(number) | Map of charm resources revisions | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "oidc-gatekeeper" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "oidc-gatekeeper" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,9 @@
 # Terraform module for oidc-gatekeeper
 
-This is a Terraform module facilitating the deployment of oidc-gatekeeper charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+This is a Terraform module facilitating the deployment of the oidc-gatekeeper charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
@@ -16,7 +19,7 @@ The module offers the following configurable inputs:
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(number) | Map of charm resources revisions | False |
+| `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
 
 ### Outputs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the oidc-gatekeeper charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+This terraform module is compatible with charms of version >= ckf-1.9 due to changes in the charm's relations.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "oidc_gatekeeper" {
+  charm {
+    name     = "oidc-gatekeeper"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,6 +2,12 @@ output "app_name" {
   value = juju_application.oidc_gatekeeper.name
 }
 
+output "peers" {
+  value = {
+    client_secret = "client-secret",
+  }
+}
+
 output "provides" {
   value = {
     oidc_client = "oidc-client",

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,15 +4,15 @@ output "app_name" {
 
 output "provides" {
   value = {
-    oidc_client  = "oidc-client",
+    oidc_client = "oidc-client",
   }
 }
 
 output "requires" {
   value = {
     dex_oidc_config = "dex-oidc-config",
-    ingress = "ingress",
-    ingress_auth = "ingress-auth"
-    logging = "logging"
+    ingress         = "ingress",
+    ingress_auth    = "ingress-auth"
+    logging         = "logging"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,18 @@
+output "app_name" {
+  value = juju_application.oidc_gatekeeper.name
+}
+
+output "provides" {
+  value = {
+    oidc_client  = "oidc-client",
+  }
+}
+
+output "requires" {
+  value = {
+    dex_oidc_config = "dex-oidc-config",
+    ingress = "ingress",
+    ingress_auth = "ingress-auth"
+    logging = "logging"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,10 +21,9 @@ variable "model_name" {
   type        = string
 }
 
-# TODO: Update to a map of strings, once juju provider 0.14 is released
 variable "resources" {
-  description = "Map of resources revisions"
-  type        = map(number)
+  description = "Map of resources"
+  type        = map(string)
   default     = null
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "oidc-gatekeeper"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+# TODO: Update to a map of strings, once juju provider 0.14 is released
+variable "resources" {
+  description = "Map of resources revisions"
+  type        = map(number)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.13.0"
+      version = "~> 0.14.0"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.13.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Closes: https://github.com/canonical/oidc-gatekeeper-operator/issues/174

Based on this PR: https://github.com/canonical/argo-operators/pull/198

**To test**

- Create juju controller with `kubeflow` model
- Run `terraform apply -var "app_name=oidcgatekeeper" -var "channel=ckf-1.9/stable" -var "model_name=kubeflow" -var "resources={oci-image: 4}"`