### PR TITLE
chore: pin terraform version

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This is essentially a cherry-pick of https://github.com/canonical/oidc-gatekeeper-operator/pull/227

The merged PR has a merged commit, so I couldn't cherry-pick directly, and wanted to avoid another merge commit.