### PR TITLE
feat: add enable-jwt config for JWT bearer token auth

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,3 +38,10 @@ options:
     type: string
     default: 'email'
     description: OpenID Connect claim whose value will be used as the userid.
+  enable-jwt:
+    type: boolean
+    default: false
+    description: |
+      Enable JWT bearer token authentication alongside cookie-based session auth.
+      When enabled, the oidc-authservice will accept Authorization header bearer tokens
+      and ID tokens in addition to session cookies.

--- a/src/charm.py
+++ b/src/charm.py
@@ -197,6 +197,14 @@ class OIDCGatekeeperOperator(CharmBase):
             "SKIP_AUTH_URLS": dex_skip_urls,
         }
 
+        if self.model.config["enable-jwt"]:
+            ret_env_vars["ACCESS_TOKEN_AUTHN"] = "jwt"
+            ret_env_vars["ACCESS_TOKEN_AUTHN_ENABLED"] = "true"
+            ret_env_vars["IDTOKEN_AUTHN_ENABLED"] = "true"
+            ret_env_vars["CACHE_ENABLED"] = "true"
+            ret_env_vars["ID_TOKEN_HEADER"] = "Authorization"
+            ret_env_vars["USERID_TOKEN_HEADER"] = "kubeflow-userid-token"
+
         if self.model.config["ca-bundle"]:
             if self._container.can_connect():
                 self._container.push(
@@ -258,15 +266,18 @@ class OIDCGatekeeperOperator(CharmBase):
                 }
             )
         if interfaces["ingress-auth"]:
+            request_headers = ["cookie", "X-Auth-Token"]
+            response_headers = ["kubeflow-userid"]
+            if self.model.config["enable-jwt"]:
+                request_headers.append("Authorization")
+                response_headers.append("kubeflow-userid-token")
+
             interfaces["ingress-auth"].send_data(
                 {
                     "service": self.model.app.name,
                     "port": self._http_port,
-                    "allowed-request-headers": [
-                        "cookie",
-                        "X-Auth-Token",
-                    ],
-                    "allowed-response-headers": ["kubeflow-userid"],
+                    "allowed-request-headers": request_headers,
+                    "allowed-response-headers": response_headers,
                 }
             )
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -193,6 +193,36 @@ def test_service_environment_uses_data_from_relation(harness):
 
 
 @patch("charm.KubernetesServicePatch", lambda x, y: None)
+def test_jwt_disabled_by_default(harness):
+    harness.add_relation("dex-oidc-config", "app", app_data={"issuer-url": "http://dex.io/dex"})
+
+    harness.begin_with_initial_hooks()
+
+    plan = harness.get_container_pebble_plan("oidc-authservice")
+    env = plan.services["oidc-authservice"].environment
+    assert "ACCESS_TOKEN_AUTHN" not in env
+    assert "ACCESS_TOKEN_AUTHN_ENABLED" not in env
+    assert "IDTOKEN_AUTHN_ENABLED" not in env
+
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def test_enable_jwt(harness):
+    harness.update_config({"enable-jwt": True})
+    harness.add_relation("dex-oidc-config", "app", app_data={"issuer-url": "http://dex.io/dex"})
+
+    harness.begin_with_initial_hooks()
+
+    plan = harness.get_container_pebble_plan("oidc-authservice")
+    env = plan.services["oidc-authservice"].environment
+    assert env["ACCESS_TOKEN_AUTHN"] == "jwt"
+    assert env["ACCESS_TOKEN_AUTHN_ENABLED"] == "true"
+    assert env["IDTOKEN_AUTHN_ENABLED"] == "true"
+    assert env["CACHE_ENABLED"] == "true"
+    assert env["ID_TOKEN_HEADER"] == "Authorization"
+    assert env["USERID_TOKEN_HEADER"] == "kubeflow-userid-token"
+
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
 @pytest.mark.parametrize(
     "expected_raise, expected_status",
     (


### PR DESCRIPTION
## Summary
- Adds an `enable-jwt` charm config option (default: `false`) to enable JWT bearer token authentication alongside cookie-based sessions
- When enabled, configures the upstream oidc-authservice with `ACCESS_TOKEN_AUTHN=jwt`, `IDTOKEN_AUTHN_ENABLED=true`, and token caching
- Updates ingress-auth relation to forward the `Authorization` header and `kubeflow-userid-token` response header when JWT is enabled

## Motivation
The upstream oidc-authservice binary already supports JWT bearer token authentication, but this charm didn't expose the configuration. This is useful for programmatic/API access to Kubeflow services without requiring browser-based login.

## Test plan
- [ ] Unit tests added for both enabled and disabled states
- [ ] Verify default behavior unchanged (cookie auth works as before)
- [ ] Deploy with `juju config oidc-gatekeeper enable-jwt=true` and verify bearer tokens are accepted